### PR TITLE
Implement a CURL(able) API

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -6,59 +6,83 @@ import play.api.mvc._
 import com.dd.plist._
 
 object Application extends Controller {
-  
-  def user(userkey:String) = Action { request =>
-    
+
+  def user(userkey: String) = Action { request =>
+
     Logger.info("Get User Account: %s" format userkey)
-    Logger.debug(request.headers.toSimpleMap.foldLeft("Headers:\n"){case (x,(y,z))=> x+y+":"+z+"\n" })
-    
-    if(userkey==uid){
-      Ok(views.html.user()).withHeaders("Content-Type"->"application/plist")
-    }else{
+    Logger.debug(request.headers.toSimpleMap.foldLeft("Headers:\n") { case (x, (y, z)) => x + y + ":" + z + "\n" })
+
+    if (userkey == uid) {
+      Ok(views.html.user()).withHeaders("Content-Type" -> "application/plist")
+    } else {
       NotFound("")
     }
   }
-  
+
   val uid = "437"
   val key = "e29"
   val dev = "85e"
-  
-  def poll(devkey:String) = Action {
+
+  def poll(devkey: String) = Action {
     Logger.info("Polling for Device: %s" format devkey)
-    if(confirmed){
-      if(devkey==dev){
-        confirmed=false
+    if (confirmed) {
+      if (devkey == dev) {
+        confirmed = false
         Redirect(routes.Application.user(uid))
-      }else{
+      } else {
         NotFound("")
       }
-    }else{
+    } else {
       Forbidden("Please Confirm Device by Email")
     }
   }
+
+  def sendEmailConfirmation(email: String) {
+    Logger.info("Sending Email Confirmation to %s" format email)
+    Logger.info("To Confirm Please Follow the Location: %s" format routes.Application.confirm(key))
+  }
   
-  def register(user:String) = Action { request =>
-    val device = dev
-    
-    Logger.info("Register New Device: %s to User: %s" format (device,user))
-    Logger.info("To Confirm Please Follow the URL: http://%s%s" format (request.headers("Host"),routes.Application.confirm(key)))
-    
-    Redirect(routes.Application.poll(dev))
+  def scrubEmail(email: String): Option[String] = email match {
+    case "" => None
+    case email => Some(email)
+  }
+  
+  def associateNewEmail(email:String): String = {
+    Logger.info("Associating New Email %s with Key %s" format (email,dev))
+    dev
+  }
+  
+  def register = Action { request =>
+    request.body.asFormUrlEncoded.map { form =>
+      form.get("email").map { emails =>
+        emails.headOption.map { dirtyemail =>
+          scrubEmail(dirtyemail).map { email =>
+            
+            // Success //
+            val device = associateNewEmail(email)
+            Logger.info("Register New Device: %s to User: %s" format (device, email))
+            sendEmailConfirmation(email)
+            Redirect(routes.Application.poll(dev))
+            
+          }.getOrElse{BadRequest("Not a valid email")}
+        }.getOrElse{BadRequest("No Valid Email Recieved")}
+      }.getOrElse{BadRequest("Registration must include an email") }
+    }.getOrElse{BadRequest("Registration type must be application/form-url-encoded") }
   }
   
   var confirmed = false
-  def confirm(confirmKey:String) = Action { request=>
-    if(confirmKey==key){
-      confirmed=true
+  def confirm(confirmKey: String) = Action { request =>
+    if (confirmKey == key) {
+      confirmed = true
       Logger.info("Confirmed Key: %s" format confirmKey)
-      Redirect("cardtapapp://"+request.headers("Host")+"/poll/" + dev)
-    }else{
+      Redirect("cardtapapp+http://" + request.headers("Host") + "/poll/" + dev)
+    } else {
       NotFound("")
     }
   }
-  
+
   def index = Action {
     Redirect("http://cardtapapp.com")
   }
-  
+
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -7,23 +7,54 @@ import com.dd.plist._
 
 object Application extends Controller {
   
-  def user(userid:String) = Action {
-    Logger.info("Get User Account: %s" format userid)
-    val nsdict = new NSDictionary()
+  def user(userkey:String) = Action { request =>
     
-    val byteArray = BinaryPropertyListWriter.writeToArray(nsdict)
-    Ok(byteArray).withHeaders("Content-Type"->"application/plist")
+    Logger.info("Get User Account: %s" format userkey)
+    Logger.debug(request.headers.toSimpleMap.foldLeft("Headers:\n"){case (x,(y,z))=> x+y+":"+z+"\n" })
+    
+    if(userkey==uid){
+      Ok(views.html.user()).withHeaders("Content-Type"->"application/plist")
+    }else{
+      NotFound("")
+    }
   }
   
-  def share(from:String,to:String) = Action {
-    Logger.info("Share from: %s to: %s" format (from,to))
-    TODO
+  val uid = "437"
+  val key = "e29"
+  val dev = "85e"
+  
+  def poll(devkey:String) = Action {
+    Logger.info("Polling for Device: %s" format devkey)
+    if(confirmed){
+      if(devkey==dev){
+        confirmed=false
+        Redirect(routes.Application.user(uid))
+      }else{
+        NotFound("")
+      }
+    }else{
+      Forbidden("Please Confirm Device by Email")
+    }
   }
   
-  def register(device:String,user:String) = Action {
-    val deviceId = "None"
-    Logger.info("Register New Device: %s to User: %s" format (deviceId,user))
-    TODO
+  def register(user:String) = Action { request =>
+    val device = dev
+    
+    Logger.info("Register New Device: %s to User: %s" format (device,user))
+    Logger.info("To Confirm Please Follow the URL: http://%s%s" format (request.headers("Host"),routes.Application.confirm(key)))
+    
+    Redirect(routes.Application.poll(dev))
+  }
+  
+  var confirmed = false
+  def confirm(confirmKey:String) = Action { request=>
+    if(confirmKey==key){
+      confirmed=true
+      Logger.info("Confirmed Key: %s" format confirmKey)
+      Redirect("cardtapapp://"+request.headers("Host")+"/poll/" + dev)
+    }else{
+      NotFound("")
+    }
   }
   
   def index = Action {

--- a/app/views/user.scala.html
+++ b/app/views/user.scala.html
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Name</key>
+    <string>Demo</string>
+    <key>Cards</key>
+    <array>
+      <string>Card One</string>
+      <string>Card Two</string>
+    </array>
+  </dict>
+</plist>

--- a/conf/routes
+++ b/conf/routes
@@ -5,7 +5,7 @@
 # Redirect Lost Users
 GET    /                            controllers.Application.index
 
-GET    /register/*user              controllers.Application.register(user)
+POST   /register                    controllers.Application.register
 GET    /confirm/*key                controllers.Application.confirm(key)
 GET    /poll/*device                controllers.Application.poll(device)
 GET    /user/*key                   controllers.Application.user(key)

--- a/conf/routes
+++ b/conf/routes
@@ -3,11 +3,11 @@
 # ~~~~
 
 # Redirect Lost Users
-GET     /                           controllers.Application.index
+GET    /                            controllers.Application.index
 
-# API
-GET    /user/*user                  controllers.Application.user(user)
-PUT    /share/*from/*to             controllers.Application.share(from,to)
-PUT    /register/*device/*user      controllers.Application.register(device,user)
+GET    /register/*user              controllers.Application.register(user)
+GET    /confirm/*key                controllers.Application.confirm(key)
+GET    /poll/*device                controllers.Application.poll(device)
+GET    /user/*key                   controllers.Application.user(key)
 
-GET     /assets/*file               controllers.Assets.at(path="/public", file)
+GET    /assets/*file                controllers.Assets.at(path="/public", file)

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -4,6 +4,7 @@ import org.specs2.mutable._
 import play.api.test._
 import play.api.test.Helpers._
 import com.dd.plist._
+import play.api.libs.ws._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import com.dd.plist.NSDictionary
@@ -25,6 +26,17 @@ class ApplicationSpec extends Specification {
         val nsdict = nsobject.asInstanceOf[NSDictionary]
 
         nsdict must not be null
+      }
+    }
+    "return an NSDictionary with an array of cards" in {
+      running(FakeApplication()) {
+        val result = controllers.Application.user("demo")(FakeRequest())
+        val nsobject = PropertyListParser.parse(contentAsBytes(result))
+        val nsdict = nsobject.asInstanceOf[NSDictionary]
+
+        val cardarray = nsdict.objectForKey("Cards").asInstanceOf[NSArray]
+        
+        cardarray must not be null
       }
     }
   }

--- a/test/controllers/Register.scala
+++ b/test/controllers/Register.scala
@@ -1,0 +1,44 @@
+package controllers
+
+import org.specs2.mutable._
+import play.api.test._
+import play.api.test.Helpers._
+import com.dd.plist._
+import play.api.libs.ws._
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import com.dd.plist.NSDictionary
+
+@RunWith(classOf[JUnitRunner])
+class RegistrationSpec extends Specification {
+
+  "Users API" should {
+    "return 201 created" in {
+      running(FakeApplication()) {
+        val device = "fja03fj093jf2390jf23f"
+        val user   = "bob@email.com"
+        
+        val result   = controllers.Application.register(device,user)(FakeRequest())
+        status(result) must equalTo(201)
+      }
+    }
+    "include the location of the registered user" in {
+      running(FakeApplication()) {
+        val device = "fja03fj093jf2390jf23f"
+        val user   = "bob@email.com"
+        
+        val result   = controllers.Application.register(device,user)(FakeRequest())
+        headers(result).get("Location").get must equalTo("/user/bob@email.com")
+      }
+    }
+    "disallow double registration" in {
+      val device = "fja03fj093jf2390jf23f"
+      val user   = "bob@email.com"
+      
+      val result1 = controllers.Application.register(device,user)(FakeRequest())
+      val result2 = controllers.Application.register(device,user)(FakeRequest())
+      
+      status(result2) must not be equalTo(201)
+    }
+  }
+}


### PR DESCRIPTION
The basics

```
GET /register/<email>
GET /confirm/<key>
GET /poll/<device>
GET /user/<uid>
```

When a device registers, a **device id** is returned by the web service. This id is random and long, around 512 bits. Something large enough to be mathematically secure. There are a few scenarios we would like to address here:

The user confirms the email on :
1. the registered device
2. _another_ iOS device
3. a non-iOS device

Since `/register/<email>` returns a device id, during a future poll the device can succeed if the user authorizes the device by email on another computer.

If the device did not initially send the registration, the confirm redirect returns the proper poll location. The new device can load the correct user.
